### PR TITLE
Fix/remove outdated counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,20 +369,17 @@ With OpenZeppelin Contracts installed, let's create a new file named `ERC721.sol
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
-import "@openzeppelin/contracts/utils/Counters.sol";
 
 contract DevconPanda is ERC721URIStorage {
-    using Counters for Counters.Counter;
-    Counters.Counter private _tokenIds;
+    uint256 private _tokenIds;
 
     constructor() ERC721("DevconPanda", "DCP") {}
 
     function mint(address user, string memory tokenURI) public returns (uint256) {
-        uint256 newItemId = _tokenIds.current();
-        _mint(user, newItemId);
+        uint256 newItemId = _tokenIds;
+        _safeMint(user, newItemId);
         _setTokenURI(newItemId, tokenURI);
-
-        _tokenIds.increment();
+        _tokenIds++;
         return newItemId;
     }
 }

--- a/codebase/src/ERC721.sol
+++ b/codebase/src/ERC721.sol
@@ -1,21 +1,18 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
-import "@openzeppelin/contracts/utils/Counters.sol";
 
 contract DevconPanda is ERC721URIStorage {
-    using Counters for Counters.Counter;
-    Counters.Counter private _tokenIds;
+    uint256 private _tokenIds;
 
     constructor() ERC721("DevconPanda", "DCP") {}
 
     function mint(address user, string memory tokenURI) public returns (uint256) {
-        uint256 newItemId = _tokenIds.current();
-        _mint(user, newItemId);
+        uint256 newItemId = _tokenIds;
+        _safeMint(user, newItemId);
         _setTokenURI(newItemId, tokenURI);
-
-        _tokenIds.increment();
+        _tokenIds++;
         return newItemId;
     }
 }


### PR DESCRIPTION
Counters is not provisioned when using 
```
forge install OpenZeppelin/openzeppelin-contracts
```
From the OpenZeppelin discussion at https://github.com/OpenZeppelin/openzeppelin-contracts/issues/4233 , `Counters` is no longer supported. 

The PR updates the example and which even works with the files that are currently provided for OpenZeppelin in this repo. 

The modified code has been tested with 
- forge build
- forge test